### PR TITLE
chore: add gitcrawl formula

### DIFF
--- a/Formula/gitcrawl.rb
+++ b/Formula/gitcrawl.rb
@@ -1,0 +1,18 @@
+class Gitcrawl < Formula
+  desc "Local-first GitHub issue and pull request crawler for maintainer triage"
+  homepage "https://github.com/openclaw/gitcrawl"
+  url "https://github.com/openclaw/gitcrawl/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "d986ca45e457119308e9fd7403a9054eb82d3396ccf15b3b1b4565cd6e15218c"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/openclaw/gitcrawl/internal/cli.version=#{version}"), "./cmd/gitcrawl"
+    doc.install "README.md", "LICENSE", "SPEC.md"
+  end
+
+  test do
+    assert_equal version.to_s, shell_output("#{bin}/gitcrawl --version").strip
+  end
+end


### PR DESCRIPTION
## Summary

- add a Homebrew formula for openclaw/gitcrawl v0.1.1
- build from the tagged source archive and inject the formula version via ldflags
- install README, LICENSE, and SPEC docs

## Tests

- brew style vincentkoc/tap/gitcrawl
- brew audit --strict --online vincentkoc/tap/gitcrawl
- brew install --build-from-source vincentkoc/tap/gitcrawl
- brew test vincentkoc/tap/gitcrawl

Note: `openclaw/tap` did not resolve via GitHub from this environment. This PR targets the actual Homebrew tap used by `brew tap vincentkoc/tap`: `vincentkoc/homebrew-tap`.